### PR TITLE
Add php8.0 and php8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PHP Bucket for [Scoop Installer](http://scoop.sh)
 
 ## Feature
-* All PHP versions from *v5.2* to *v7*
+* All PHP versions from *v5.2* to *v8.1*
 * Persistent custom configuration files
 * Auto update enabled
 

--- a/bucket/php8.0-nts.json
+++ b/bucket/php8.0-nts.json
@@ -1,0 +1,47 @@
+{
+    "homepage": "https://windows.php.net/downloads/releases/",
+    "version": "8.0.13",
+    "license": {
+        "identifier": "PHP-3.01",
+        "url": "https://secure.php.net/license/"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://windows.php.net/downloads/releases/php-8.0.13-nts-Win32-vs16-x64.zip",
+            "hash": "ff7819531d143bb47206eeafff232d2141106e883f5527760fb837e4f0f49a9e"
+        },
+        "32bit": {
+            "url": "https://windows.php.net/downloads/releases/php-8.0.13-nts-Win32-vs16-x86.zip",
+            "hash": "f1373402388c56f3d278afb39bffd7ade834668f7e18d225ac9ee22683a3e521"
+        }
+    },
+    "bin": [
+        "php.exe",
+        "php-cgi.exe"
+    ],
+    "persist": "conf.d",
+    "env_set": {
+        "PHP_INI_SCAN_DIR": "$persist_dir;$dir\\conf.d;"
+    },
+    "post_install": "if($bucket) { . \"$(Find-BucketDirectory $bucket\\bin\\postinstall.ps1)\" -dir \"$dir\" }",
+    "checkver": {
+        "url": "https://windows.php.net/download/",
+        "re": "<h3 id=\"php-8.0\".*?>.*?\\(([\\d.-]+)\\)</h3>"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://windows.php.net/downloads/releases/php-$version-nts-Win32-vs16-x64.zip"
+            },
+            "32bit": {
+                "url": "https://windows.php.net/downloads/releases/php-$version-nts-Win32-vs16-x86.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/sha256sum.txt"
+        }
+    },
+    "suggest": {
+        "vcredist": "extras/vcredist2019"
+    }
+}

--- a/bucket/php8.0.json
+++ b/bucket/php8.0.json
@@ -1,0 +1,47 @@
+{
+    "homepage": "https://windows.php.net/downloads/releases/",
+    "version": "8.0.13",
+    "license": {
+        "identifier": "PHP-3.01",
+        "url": "https://secure.php.net/license/"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://windows.php.net/downloads/releases/php-8.0.13-Win32-vs16-x64.zip",
+            "hash": "35d056d03037c92b1401af71a232ee24f6635e7723ddd71c1bebe9b6a7d49e49"
+        },
+        "32bit": {
+            "url": "https://windows.php.net/downloads/releases/php-8.0.13-Win32-vs16-x86.zip",
+            "hash": "24f7afb0964c60ac0968c9403e1e07dbe0529aab86b3f12383ce72079b260083"
+        }
+    },
+    "bin": [
+        "php.exe",
+        "php-cgi.exe"
+    ],
+    "persist": "conf.d",
+    "env_set": {
+        "PHP_INI_SCAN_DIR": "$persist_dir;$dir\\conf.d;"
+    },
+    "post_install": "if($bucket) { . \"$(Find-BucketDirectory $bucket\\bin\\postinstall.ps1)\" -dir \"$dir\" }",
+    "checkver": {
+        "url": "https://windows.php.net/download/",
+        "re": "<h3 id=\"php-8.0\".*?>.*?\\(([\\d.-]+)\\)</h3>"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://windows.php.net/downloads/releases/php-$version-Win32-vs16-x64.zip"
+            },
+            "32bit": {
+                "url": "https://windows.php.net/downloads/releases/php-$version-Win32-vs16-x86.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/sha256sum.txt"
+        }
+    },
+    "suggest": {
+        "vcredist": "extras/vcredist2019"
+    }
+}

--- a/bucket/php8.1-nts.json
+++ b/bucket/php8.1-nts.json
@@ -1,0 +1,47 @@
+{
+    "homepage": "https://windows.php.net/downloads/releases/",
+    "version": "8.1.0",
+    "license": {
+        "identifier": "PHP-3.01",
+        "url": "https://secure.php.net/license/"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://windows.php.net/downloads/releases/php-8.1.0-nts-Win32-vs16-x64.zip",
+            "hash": "6676926044ba9409cb141575f79e844153f025bcc4deba3e000196c9a6366b67"
+        },
+        "32bit": {
+            "url": "https://windows.php.net/downloads/releases/php-8.1.0-nts-Win32-vs16-x86.zip",
+            "hash": "6b9ed23208f9a16cf4904ba4ee7bf684879b1fd2ffbb019123006dedd46270bb"
+        }
+    },
+    "bin": [
+        "php.exe",
+        "php-cgi.exe"
+    ],
+    "persist": "conf.d",
+    "env_set": {
+        "PHP_INI_SCAN_DIR": "$persist_dir;$dir\\conf.d;"
+    },
+    "post_install": "if($bucket) { . \"$(Find-BucketDirectory $bucket\\bin\\postinstall.ps1)\" -dir \"$dir\" }",
+    "checkver": {
+        "url": "https://windows.php.net/download/",
+        "re": "<h3 id=\"php-8.1\".*?>.*?\\(([\\d.-]+)\\)</h3>"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://windows.php.net/downloads/releases/php-$version-nts-Win32-vs16-x64.zip"
+            },
+            "32bit": {
+                "url": "https://windows.php.net/downloads/releases/php-$version-nts-Win32-vs16-x86.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/sha256sum.txt"
+        }
+    },
+    "suggest": {
+        "vcredist": "extras/vcredist2019"
+    }
+}

--- a/bucket/php8.1.json
+++ b/bucket/php8.1.json
@@ -1,0 +1,47 @@
+{
+    "homepage": "https://windows.php.net/downloads/releases/",
+    "version": "8.1.0",
+    "license": {
+        "identifier": "PHP-3.01",
+        "url": "https://secure.php.net/license/"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://windows.php.net/downloads/releases/php-8.1.0-Win32-vs16-x64.zip",
+            "hash": "4c87a2f9b00bed1a40cca30ad18cc6564013f51faa1b6e4e636625e0ad5ae125"
+        },
+        "32bit": {
+            "url": "https://windows.php.net/downloads/releases/php-8.1.0-Win32-vs16-x86.zip",
+            "hash": "fcf29c5547f2b88dd19bca9ef4bb76a829cc4c4861b2235c00b9c6a3fcc873c8"
+        }
+    },
+    "bin": [
+        "php.exe",
+        "php-cgi.exe"
+    ],
+    "persist": "conf.d",
+    "env_set": {
+        "PHP_INI_SCAN_DIR": "$persist_dir;$dir\\conf.d;"
+    },
+    "post_install": "if($bucket) { . \"$(Find-BucketDirectory $bucket\\bin\\postinstall.ps1)\" -dir \"$dir\" }",
+    "checkver": {
+        "url": "https://windows.php.net/download/",
+        "re": "<h3 id=\"php-8.1\".*?>.*?\\(([\\d.-]+)\\)</h3>"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://windows.php.net/downloads/releases/php-$version-Win32-vs16-x64.zip"
+            },
+            "32bit": {
+                "url": "https://windows.php.net/downloads/releases/php-$version-Win32-vs16-x86.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/sha256sum.txt"
+        }
+    },
+    "suggest": {
+        "vcredist": "extras/vcredist2019"
+    }
+}


### PR DESCRIPTION
This PR adds support for PHP v8.0.13 and PHP v8.1.0.

My update procedure:
1. Copy 7.4's JSON files.
2. Change names to specified versions
3. Update `7.4` to `8.0` or `8.1`
4. Update VC15 to vs16 in URLs
5. Update commit hashes to those specified at https://windows.php.net/downloads/releases/sha256sum.txt