### PR TITLE
php8.4(-nts): Add version 8.4.12

### DIFF
--- a/bucket/php8.4-nts.json
+++ b/bucket/php8.4-nts.json
@@ -7,7 +7,7 @@
         "url": "https://secure.php.net/license/"
     },
     "suggest": {
-        "vcredist": "extras/vcredist2019"
+        "vcredist": "extras/vcredist2022"
     },
     "architecture": {
         "32bit": {

--- a/bucket/php8.4-nts.json
+++ b/bucket/php8.4-nts.json
@@ -1,47 +1,48 @@
 {
+    "version": "8.4.12",
     "homepage": "https://windows.php.net/downloads/releases/",
-    "version": "8.4.4",
+    "description": "PHP(8.4, single thread only builds) is a widely-used open-source scripting language that is especially suited for web development and can be embedded into HTML.",
     "license": {
         "identifier": "PHP-3.01",
         "url": "https://secure.php.net/license/"
     },
+    "suggest": {
+        "vcredist": "extras/vcredist2019"
+    },
     "architecture": {
-        "64bit": {
-            "url": "https://windows.php.net/downloads/releases/php-8.4.4-nts-Win32-vs17-x64.zip",
-            "hash": "950834361d4a03cd67c2be12eff2758b2fbffc46abb2671b2929b0d4c0e8b953"
-        },
         "32bit": {
-            "url": "https://windows.php.net/downloads/releases/php-8.4.4-nts-Win32-vs17-x86.zip",
-            "hash": "eae76270758c3f76b2fbc133d66db96768cb8d967d2994aa07ccd32c94f70064"
+            "url": "https://windows.php.net/downloads/releases/php-8.4.12-nts-Win32-vs17-x86.zip",
+            "hash": "cdec5781310f55542ceb643282bd10ea06e017801a794072eb90cd4d9459fff5"
+        },
+        "64bit": {
+            "url": "https://windows.php.net/downloads/releases/php-8.4.12-nts-Win32-vs17-x64.zip",
+            "hash": "9955f021aeca980310e467e168df5c3ae933d99cbb4e4cc7de668558061fdeb3"
         }
+    },
+    "post_install": "if($bucket) { . \"$(Find-BucketDirectory $bucket\\bin\\postinstall.ps1)\" -dir \"$dir\" }",
+    "env_set": {
+        "PHP_INI_SCAN_DIR": "$persist_dir;$dir\\conf.d;"
     },
     "bin": [
         "php.exe",
         "php-cgi.exe"
     ],
     "persist": "conf.d",
-    "env_set": {
-        "PHP_INI_SCAN_DIR": "$persist_dir;$dir\\conf.d;"
-    },
-    "post_install": "if($bucket) { . \"$(Find-BucketDirectory $bucket\\bin\\postinstall.ps1)\" -dir \"$dir\" }",
     "checkver": {
         "url": "https://windows.php.net/download/",
         "re": "<h3 id=\"php-8.4\".*?>.*?\\(([\\d.-]+)\\)</h3>"
     },
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://windows.php.net/downloads/releases/php-$version-nts-Win32-vs17-x64.zip"
-            },
-            "32bit": {
-                "url": "https://windows.php.net/downloads/releases/php-$version-nts-Win32-vs17-x86.zip"
-            }
-        },
         "hash": {
             "url": "$baseurl/sha256sum.txt"
+        },
+        "architecture": {
+            "32bit": {
+                "url": "https://windows.php.net/downloads/releases/php-$version-nts-Win32-vs17-x86.zip"
+            },
+            "64bit": {
+                "url": "https://windows.php.net/downloads/releases/php-$version-nts-Win32-vs17-x64.zip"
+            }
         }
-    },
-    "suggest": {
-        "vcredist": "extras/vcredist2019"
     }
 }

--- a/bucket/php8.4-nts.json
+++ b/bucket/php8.4-nts.json
@@ -1,10 +1,10 @@
 {
     "version": "8.4.12",
     "homepage": "https://windows.php.net/downloads/releases/",
-    "description": "PHP(8.4, single thread only builds) is a widely-used open-source scripting language that is especially suited for web development and can be embedded into HTML.",
+    "description": "PHP 8.4 (non-thread-safe/NTS build) for Windows. Widely used open-source scripting language for web development.",
     "license": {
         "identifier": "PHP-3.01",
-        "url": "https://secure.php.net/license/"
+        "url": "https://www.php.net/license/"
     },
     "suggest": {
         "vcredist": "extras/vcredist2022"

--- a/bucket/php8.4-nts.json
+++ b/bucket/php8.4-nts.json
@@ -1,0 +1,47 @@
+{
+    "homepage": "https://windows.php.net/downloads/releases/",
+    "version": "8.4.4",
+    "license": {
+        "identifier": "PHP-3.01",
+        "url": "https://secure.php.net/license/"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://windows.php.net/downloads/releases/php-8.4.4-nts-Win32-vs17-x64.zip",
+            "hash": "950834361d4a03cd67c2be12eff2758b2fbffc46abb2671b2929b0d4c0e8b953"
+        },
+        "32bit": {
+            "url": "https://windows.php.net/downloads/releases/php-8.4.4-nts-Win32-vs17-x86.zip",
+            "hash": "eae76270758c3f76b2fbc133d66db96768cb8d967d2994aa07ccd32c94f70064"
+        }
+    },
+    "bin": [
+        "php.exe",
+        "php-cgi.exe"
+    ],
+    "persist": "conf.d",
+    "env_set": {
+        "PHP_INI_SCAN_DIR": "$persist_dir;$dir\\conf.d;"
+    },
+    "post_install": "if($bucket) { . \"$(Find-BucketDirectory $bucket\\bin\\postinstall.ps1)\" -dir \"$dir\" }",
+    "checkver": {
+        "url": "https://windows.php.net/download/",
+        "re": "<h3 id=\"php-8.4\".*?>.*?\\(([\\d.-]+)\\)</h3>"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://windows.php.net/downloads/releases/php-$version-nts-Win32-vs17-x64.zip"
+            },
+            "32bit": {
+                "url": "https://windows.php.net/downloads/releases/php-$version-nts-Win32-vs17-x86.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/sha256sum.txt"
+        }
+    },
+    "suggest": {
+        "vcredist": "extras/vcredist2019"
+    }
+}

--- a/bucket/php8.4-nts.json
+++ b/bucket/php8.4-nts.json
@@ -33,9 +33,6 @@
         "re": "<h3 id=\"php-8.4\".*?>.*?\\(([\\d.-]+)\\)</h3>"
     },
     "autoupdate": {
-        "hash": {
-            "url": "$baseurl/sha256sum.txt"
-        },
         "architecture": {
             "32bit": {
                 "url": "https://windows.php.net/downloads/releases/php-$version-nts-Win32-vs17-x86.zip"
@@ -43,6 +40,9 @@
             "64bit": {
                 "url": "https://windows.php.net/downloads/releases/php-$version-nts-Win32-vs17-x64.zip"
             }
+        },
+        "hash": {
+            "url": "$baseurl/sha256sum.txt"
         }
     }
 }

--- a/bucket/php8.4.json
+++ b/bucket/php8.4.json
@@ -1,10 +1,10 @@
 {
     "version": "8.4.12",
     "homepage": "https://windows.php.net/downloads/releases/",
-    "description": "PHP(8.4, multithread capable builds) is a widely-used open-source scripting language that is especially suited for web development and can be embedded into HTML.",
+    "description": "PHP 8.4 (thread-safe/TS build) for Windows. Widely used open-source scripting language for web development.",
     "license": {
         "identifier": "PHP-3.01",
-        "url": "https://secure.php.net/license/"
+        "url": "https://www.php.net/license/"
     },
     "suggest": {
         "vcredist": "extras/vcredist2022"

--- a/bucket/php8.4.json
+++ b/bucket/php8.4.json
@@ -1,0 +1,47 @@
+{
+    "homepage": "https://windows.php.net/downloads/releases/",
+    "version": "8.4.4",
+    "license": {
+        "identifier": "PHP-3.01",
+        "url": "https://secure.php.net/license/"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://windows.php.net/downloads/releases/php-8.4.4-Win32-vs17-x64.zip",
+            "hash": "879da3a8d56b4c682610749c8bdc8b634862279653b07b8c52187dfa5e19ab42"
+        },
+        "32bit": {
+            "url": "https://windows.php.net/downloads/releases/php-8.4.4-Win32-vs17-x86.zip",
+            "hash": "8a33855a9c4fa0539e7cbebf65952030db754483a52bff57bb72facae1b9037e"
+        }
+    },
+    "bin": [
+        "php.exe",
+        "php-cgi.exe"
+    ],
+    "persist": "conf.d",
+    "env_set": {
+        "PHP_INI_SCAN_DIR": "$persist_dir;$dir\\conf.d;"
+    },
+    "post_install": "if($bucket) { . \"$(Find-BucketDirectory $bucket\\bin\\postinstall.ps1)\" -dir \"$dir\" }",
+    "checkver": {
+        "url": "https://windows.php.net/download/",
+        "re": "<h3 id=\"php-8.4\".*?>.*?\\(([\\d.-]+)\\)</h3>"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://windows.php.net/downloads/releases/php-$version-Win32-vs17-x64.zip"
+            },
+            "32bit": {
+                "url": "https://windows.php.net/downloads/releases/php-$version-Win32-vs17-x86.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/sha256sum.txt"
+        }
+    },
+    "suggest": {
+        "vcredist": "extras/vcredist2019"
+    }
+}

--- a/bucket/php8.4.json
+++ b/bucket/php8.4.json
@@ -1,47 +1,48 @@
 {
+    "version": "8.4.12",
     "homepage": "https://windows.php.net/downloads/releases/",
-    "version": "8.4.4",
+    "description": "PHP(8.4, multithread capable builds) is a widely-used open-source scripting language that is especially suited for web development and can be embedded into HTML.",
     "license": {
         "identifier": "PHP-3.01",
         "url": "https://secure.php.net/license/"
     },
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
     "architecture": {
-        "64bit": {
-            "url": "https://windows.php.net/downloads/releases/php-8.4.4-Win32-vs17-x64.zip",
-            "hash": "879da3a8d56b4c682610749c8bdc8b634862279653b07b8c52187dfa5e19ab42"
-        },
         "32bit": {
-            "url": "https://windows.php.net/downloads/releases/php-8.4.4-Win32-vs17-x86.zip",
-            "hash": "8a33855a9c4fa0539e7cbebf65952030db754483a52bff57bb72facae1b9037e"
+            "url": "https://windows.php.net/downloads/releases/php-8.4.12-Win32-vs17-x86.zip",
+            "hash": "ae31e43ea29c3684a4bacf3dd25947dc940bba6b33d159f895710d9cd5fbc678"
+        },
+        "64bit": {
+            "url": "https://windows.php.net/downloads/releases/php-8.4.12-Win32-vs17-x64.zip",
+            "hash": "602dbfd1a65e99e8bb29c7ff2c8a7888f3cd72a8162de99b7860bbe117779d1c"
         }
+    },
+    "post_install": "if($bucket) { . \"$(Find-BucketDirectory $bucket\\bin\\postinstall.ps1)\" -dir \"$dir\" }",
+    "env_set": {
+        "PHP_INI_SCAN_DIR": "$persist_dir;$dir\\conf.d;"
     },
     "bin": [
         "php.exe",
         "php-cgi.exe"
     ],
     "persist": "conf.d",
-    "env_set": {
-        "PHP_INI_SCAN_DIR": "$persist_dir;$dir\\conf.d;"
-    },
-    "post_install": "if($bucket) { . \"$(Find-BucketDirectory $bucket\\bin\\postinstall.ps1)\" -dir \"$dir\" }",
     "checkver": {
         "url": "https://windows.php.net/download/",
         "re": "<h3 id=\"php-8.4\".*?>.*?\\(([\\d.-]+)\\)</h3>"
     },
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://windows.php.net/downloads/releases/php-$version-Win32-vs17-x64.zip"
-            },
-            "32bit": {
-                "url": "https://windows.php.net/downloads/releases/php-$version-Win32-vs17-x86.zip"
-            }
-        },
         "hash": {
             "url": "$baseurl/sha256sum.txt"
+        },
+        "architecture": {
+            "32bit": {
+                "url": "https://windows.php.net/downloads/releases/php-$version-Win32-vs17-x86.zip"
+            },
+            "64bit": {
+                "url": "https://windows.php.net/downloads/releases/php-$version-Win32-vs17-x64.zip"
+            }
         }
-    },
-    "suggest": {
-        "vcredist": "extras/vcredist2019"
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added installable packages for PHP 8.4.12 (TS) and PHP 8.4.12 NTS.
  * Supports 32-bit and 64-bit builds with verified downloads.
  * Post-install sets PHP_INI_SCAN_DIR and persists the conf.d directory.
  * Exposes php and php-cgi commands on the PATH.
  * Automatic version checks and autoupdate configured for future releases.
  * Suggests installing the required Visual C++ Redistributable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->