### PR TITLE
PHP: Add version 8.5

### DIFF
--- a/bucket/php8.5-nts.json
+++ b/bucket/php8.5-nts.json
@@ -1,0 +1,49 @@
+{
+    "version": "8.5.8",
+    "homepage": "https://downloads.php.net/~windows/releases/",
+    "description": "PHP 8.5 (non-thread-safe/NTS build) for Windows. Widely used open-source scripting language for web development.",
+    "license": {
+        "identifier": "PHP-3.01",
+        "url": "https://www.php.net/license/"
+    },
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
+    "architecture": {
+        "32bit": {
+            "url": "https://downloads.php.net/~windows/releases/archives/php-8.5.8-nts-Win32-vs17-x86.zip",
+            "hash": "421ee83fb2288c79c56d7488e0f658070f73b6ad072bacc6b3572bc8ccdf57f9"
+        },
+        "64bit": {
+            "url": "https://downloads.php.net/~windows/releases/archives/php-8.5.8-nts-Win32-vs17-x64.zip",
+            "hash": "63a3f6493f37c9ff3e288ec16621222a6cda5167dd1abffec0019e7f18c8e7e9"
+        }
+    },
+    "post_install": "if($bucket) { . \"$(Find-BucketDirectory $bucket\\bin\\postinstall.ps1)\" -dir \"$dir\" }",
+    "env_set": {
+        "PHP_INI_SCAN_DIR": "$persist_dir;$dir\\conf.d;"
+    },
+    "bin": [
+        "php.exe",
+        "php-cgi.exe"
+    ],
+    "persist": "conf.d",
+    "checkver": {
+        "url": "https://www.php.net/releases/branches.php",
+        "jsonpath": "$.[?(@.branch == '8.5')].latest"
+    },
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://downloads.php.net/~windows/releases/archives/php-$version-nts-Win32-vs17-x86.zip"
+            },
+            "64bit": {
+                "url": "https://downloads.php.net/~windows/releases/archives/php-$version-nts-Win32-vs17-x64.zip"
+            }
+        },
+        "hash": {
+            "url": "https://downloads.php.net/~windows/releases/releases.json",
+            "jsonpath": "$..[?(@.path == '$basename')].sha256"
+        }
+    }
+}

--- a/bucket/php8.5.json
+++ b/bucket/php8.5.json
@@ -1,0 +1,49 @@
+{
+    "version": "8.5.8",
+    "homepage": "https://downloads.php.net/~windows/releases/",
+    "description": "PHP 8.5 (thread-safe/TS build) for Windows. Widely used open-source scripting language for web development.",
+    "license": {
+        "identifier": "PHP-3.01",
+        "url": "https://www.php.net/license/"
+    },
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
+    "architecture": {
+        "32bit": {
+            "url": "https://downloads.php.net/~windows/releases/archives/php-8.5.8-Win32-vs17-x86.zip",
+            "hash": "86a01ec179c6aba884e72b8b399589b6aab7749ee6bf782adb8c335f7c756778"
+        },
+        "64bit": {
+            "url": "https://downloads.php.net/~windows/releases/archives/php-8.5.8-Win32-vs17-x64.zip",
+            "hash": "a7323e50a1e29fddc278d9297ca9a4ec134bd1cca5396af39115284a125cab2f"
+        }
+    },
+    "post_install": "if($bucket) { . \"$(Find-BucketDirectory $bucket\\bin\\postinstall.ps1)\" -dir \"$dir\" }",
+    "env_set": {
+        "PHP_INI_SCAN_DIR": "$persist_dir;$dir\\conf.d;"
+    },
+    "bin": [
+        "php.exe",
+        "php-cgi.exe"
+    ],
+    "persist": "conf.d",
+    "checkver": {
+        "url": "https://www.php.net/releases/branches.php",
+        "jsonpath": "$.[?(@.branch == '8.5')].latest"
+    },
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://downloads.php.net/~windows/releases/archives/php-$version-Win32-vs17-x86.zip"
+            },
+            "64bit": {
+                "url": "https://downloads.php.net/~windows/releases/archives/php-$version-Win32-vs17-x64.zip"
+            }
+        },
+        "hash": {
+            "url": "https://downloads.php.net/~windows/releases/releases.json",
+            "jsonpath": "$..[?(@.path == '$basename')].sha256"
+        }
+    }
+}


### PR DESCRIPTION
Closes #32

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) 

I installed it on Windows Server 2025.

``` powershell
sudo scoop install --global [my-bucket]/php8.5-nts
php -v
```

> PHP 8.5.8 (cli) (built: Jul  1 2026 04:03:04) (NTS Visual C++ 2022 x64)
> Copyright (c) The PHP Group
> Built by The PHP Group
> Zend Engine v4.5.8, Copyright (c) Zend Technologies
>     with Zend OPcache v8.5.8, Copyright (c), by Zend Technologies

``` powershell
sudo scoop install --global [my-bucket]/php8.5
php -v
```
> PHP 8.5.8 (cli) (built: Jul  1 2026 04:02:00) (ZTS Visual C++ 2022 x64)
> Copyright (c) The PHP Group
> Built by The PHP Group
> Zend Engine v4.5.8, Copyright (c) Zend Technologies
>     with Zend OPcache v8.5.8, Copyright (c), by Zend Technologies

I used the `checkver` in Versions Bucket as a reference.

https://github.com/ScoopInstaller/Versions/blob/77354e0a6e47cb425347598c42b9f2dd551f5beb/bucket/php84.json#L44
https://github.com/ScoopInstaller/Main/blob/412a0cd57ee4fce1c9ada4d2ea919f6212f6c44b/bucket/php.json#L57